### PR TITLE
Fix Japanese text detection in FetcherAgent

### DIFF
--- a/agents/fetcher.py
+++ b/agents/fetcher.py
@@ -444,5 +444,5 @@ class FetcherAgent:
         """簡易的な日本語判定"""
         if not text:
             return False
-        japanese_chars = re.findall(r"[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff]", text)
+        japanese_chars = re.findall("[぀-ヿ㐀-䶿一-鿿]", text)
         return len(japanese_chars) >= max(1, int(len(text) * 0.1))


### PR DESCRIPTION
## Summary
- correct regex in `_is_japanese` to properly detect Japanese characters

## Testing
- `python -m py_compile agents/fetcher.py`
- `python -m compileall agents/fetcher.py`

------
https://chatgpt.com/codex/tasks/task_e_686fcb24d44483258803ece63c9ae04b