### PR TITLE
feat: add expo mobile app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.pyc
+node_modules/
+mobile-app/node_modules/
+mobile-app/.expo/
+.expo/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ python test_system.py --send-test
 python main.py
 ```
 
+### 4. Expo モバイルアプリ配布
+
+```bash
+cd mobile-app
+npm install
+npx expo login               # Expoアカウントでログイン
+npx eas build -p android --profile production
+npx eas build -p ios --profile production
+```
+
+Expo のダッシュボードから生成されたビルドをダウンロードし、アプリストアへ配布できます。
+
 ## 📂 ディレクトリ構成
 
 ```
@@ -87,6 +99,7 @@ news_agent/
 │   └── keywords.yaml         # 分類キーワード
 ├── utils/
 │   └── logger.py             # ログ管理
+├── mobile-app/               # Expoベースのモバイルアプリ
 ├── .env                      # 環境変数
 ├── requirements.txt          # 依存関係
 ├── test_system.py            # テストスクリプト

--- a/mobile-app/App.js
+++ b/mobile-app/App.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Welcome to SlackAgent Mobile!</Text>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "SlackAgent",
+    "slug": "slackagent",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "platforms": ["ios", "android", "web"],
+    "assetBundlePatterns": ["**/*"]
+  }
+}

--- a/mobile-app/eas.json
+++ b/mobile-app/eas.json
@@ -1,0 +1,22 @@
+{
+  "cli": {
+    "version": ">= 3.13.1"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {
+      "android": {
+        "buildType": "app-bundle"
+      },
+      "ios": {
+        "simulator": false
+      }
+    }
+  }
+}

--- a/mobile-app/package.json
+++ b/mobile-app/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "slackagent-mobile",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "expo-status-bar": "^2.0.0",
+    "react": "18.2.0",
+    "react-native": "0.73.4"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.20.0"
+  },
+  "private": true
+}


### PR DESCRIPTION
## Summary
- add Expo-based mobile project with build config for distribution
- document Expo build steps in README
- include ignore rules for Node and Python artifacts

## Testing
- `python test_system.py`

------
https://chatgpt.com/codex/tasks/task_e_689c06b32d548325a7ebe37b67356616