### PR TITLE
feat: configure iOS bundle identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,15 +74,18 @@ python main.py
 
 ### 4. Expo モバイルアプリ配布
 
+App Store 配布にあたり、先に `mobile-app/app.json` の `ios.bundleIdentifier` を自分の App ID に設定してください。
+
 ```bash
 cd mobile-app
 npm install
 npx expo login               # Expoアカウントでログイン
 npx eas build -p android --profile production
 npx eas build -p ios --profile production
+npx eas submit -p ios --latest
 ```
 
-Expo のダッシュボードから生成されたビルドをダウンロードし、アプリストアへ配布できます。
+Expo のダッシュボードから生成されたビルドを確認し、`eas submit` で App Store Connect へアップロードできます。
 
 ## 📂 ディレクトリ構成
 

--- a/mobile-app/app.json
+++ b/mobile-app/app.json
@@ -5,6 +5,10 @@
     "version": "1.0.0",
     "orientation": "portrait",
     "platforms": ["ios", "android", "web"],
-    "assetBundlePatterns": ["**/*"]
+    "assetBundlePatterns": ["**/*"],
+    "ios": {
+      "bundleIdentifier": "com.example.slackagent",
+      "supportsTablet": true
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow Expo mobile app builds to include an iOS bundle identifier for App Store distribution
- document bundle identifier setup and `eas submit` flow for uploading to App Store Connect

## Testing
- `python test_system.py`

------
https://chatgpt.com/codex/tasks/task_e_689c089674f88325b4f568fe174d79b4