### PR TITLE
Fix dependency conflicts in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,12 +6,12 @@ nltk==3.8.1
 pyyaml==6.0.1
 python-dotenv==1.0.0
 lxml==4.9.3
-torch==2.1.2
+torch==2.2.0
 transformers==4.35.2
 numpy==1.26.4
 sentencepiece==0.1.99
 protobuf==4.25.3
-google-generativeai==0.5.0
+google-generativeai==0.3.2
 langchain-core==0.1.52
 langchain-google-genai==0.0.6
 


### PR DESCRIPTION
## Summary
- Align google-generativeai with langchain-google-genai by downgrading to 0.3.2
- Update torch to 2.2.0 to ensure availability on current Python versions

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a160e2a4f083258ef3302c6dce6346