### PR TITLE
Gracefully handle Gemini API quota exhaustion

### DIFF
--- a/agents/classifier.py
+++ b/agents/classifier.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Any
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 from utils.logger import setup_logger, log_error
+from google.api_core.exceptions import ResourceExhausted
 
 
 class ClassifierAgent:
@@ -78,6 +79,9 @@ class ClassifierAgent:
             category = data.get("category", "Unknown")
             confidence = float(data.get("confidence", 0.0))
             return {"category": category, "confidence": confidence}
+        except ResourceExhausted as e:
+            self.logger.warning(f"分類でGemini APIのクォータを超過しました: {e}")
+            return {}
         except Exception as e:
             self.logger.debug(f"分類失敗: {e}")
             return {}

--- a/agents/fetcher.py
+++ b/agents/fetcher.py
@@ -11,6 +11,7 @@ from utils.logger import setup_logger, log_error
 import re
 from urllib.parse import urlparse
 from langchain_google_genai import ChatGoogleGenerativeAI
+from google.api_core.exceptions import ResourceExhausted
 
 class FetcherAgent:
     """
@@ -450,6 +451,9 @@ class FetcherAgent:
             data = json.loads(response.content)
             tags = data.get("tags", []) if isinstance(data, dict) else data
             return [str(t) for t in tags][:5]
+        except ResourceExhausted as e:
+            self.logger.warning(f"タグ抽出でGemini APIのクォータを超過しました: {e}")
+            return []
         except Exception as e:
             self.logger.debug(f"タグ抽出失敗: {e}")
             return []

--- a/agents/notifier.py
+++ b/agents/notifier.py
@@ -6,6 +6,7 @@ from typing import List, Dict, Any
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 from utils.logger import setup_logger, log_error
+from google.api_core.exceptions import ResourceExhausted
 
 class NotifierAgent:
     def __init__(self, webhook_url: str, log_level: str = "INFO"):
@@ -125,6 +126,9 @@ class NotifierAgent:
         try:
             response = self.llm.invoke(prompt)
             return response.content.strip()
+        except ResourceExhausted as e:
+            self.logger.warning(f"コメント生成でGemini APIのクォータを超過しました: {e}")
+            return ""
         except Exception as e:
             self.logger.debug(f"コメント生成失敗: {e}")
             return ""

--- a/agents/summarizer.py
+++ b/agents/summarizer.py
@@ -3,6 +3,7 @@ from typing import List, Dict, Any
 
 from langchain_google_genai import ChatGoogleGenerativeAI
 from utils.logger import setup_logger, log_error
+from google.api_core.exceptions import ResourceExhausted
 
 class SummarizerAgent:
     """LangChain を通じて Google Gemini で記事要約を行うエージェント"""
@@ -65,6 +66,9 @@ class SummarizerAgent:
             )
             response = self.llm.invoke(prompt)
             return response.content.strip()
+        except ResourceExhausted as e:
+            self.logger.warning(f"Gemini 要約でクォータを超過しました: {e}")
+            return "（Geminiのクォータを超過しました）"
         except Exception as e:
             self.logger.warning(f"Gemini 要約失敗: {str(e)}")
             return "（Geminiによる要約に失敗しました）"


### PR DESCRIPTION
## Summary
- warn and skip tag extraction when Gemini API quota is exceeded
- warn and skip article classification, summarization, and comment generation on quota errors

## Testing
- `python -m pytest`
- `python - <<'PY'\nimport agents.fetcher, agents.classifier, agents.summarizer, agents.notifier\nprint('imports ok')\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68a1692bf55c8325a1e296c9b06d95b0