### PR TITLE
Gracefully handle Gemini API quota exhaustion

### DIFF
--- a/utils/quota.py
+++ b/utils/quota.py
@@ -1,0 +1,20 @@
+import os
+from threading import Lock
+
+# Simple in-memory quota manager for Gemini API requests
+_max_requests = int(os.getenv("GEMINI_MAX_REQUESTS", "50"))
+_lock = Lock()
+_count = 0
+
+def can_make_request() -> bool:
+    """Return True if another Gemini request can be made."""
+    with _lock:
+        return _count < _max_requests
+
+
+def record_request() -> int:
+    """Record a Gemini request and return the current count."""
+    global _count
+    with _lock:
+        _count += 1
+        return _count


### PR DESCRIPTION
## Summary
- track Gemini API requests with a shared in-memory quota manager
- skip tag extraction, classification, summaries, and comments once the configured limit is reached

## Testing
- `pip install -r requirements.txt` *(fails: No matching distribution for torch==2.1.2)*
- `pip install feedparser requests pyyaml lxml beautifulsoup4 sumy nltk protobuf google-generativeai==0.3.2 langchain-core==0.1.52 langchain-google-genai==0.0.6 python-dotenv`
- `python -m pytest`
- `python - <<'PY'\nimport agents.fetcher, agents.classifier, agents.summarizer, agents.notifier\nprint('imports ok')\nPY`


------
https://chatgpt.com/codex/tasks/task_e_68a1692bf55c8325a1e296c9b06d95b0